### PR TITLE
Add Razorpay Payment Gateway, PaymentMethod and PaymentSource

### DIFF
--- a/app/models/solidus_razorpay.rb
+++ b/app/models/solidus_razorpay.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SolidusRazorpay
+  def self.table_name_prefix
+    'solidus_razorpay_'
+  end
+end

--- a/app/models/solidus_razorpay/gateway.rb
+++ b/app/models/solidus_razorpay/gateway.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusRazorpay
+  class Gateway
+    def initialize(razorpay_key, razorpay_secret)
+      Razorpay.setup(razorpay_key, razorpay_secret)
+    end
+
+    def authorize(_amount, payment_source, _gateway_options); end
+
+    def capture(float_amount, order_number, gateway_options); end
+
+    def void(order_number, gateway_options); end
+
+    def purchase(float_amount, payment_source, gateway_options); end
+  end
+end

--- a/app/models/solidus_razorpay/payment_source.rb
+++ b/app/models/solidus_razorpay/payment_source.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_dependency 'solidus_razorpay'
+
+module SolidusRazorpay
+  class PaymentSource < SolidusSupport.payment_source_parent_class
+    enum status: { created: 0, authorized: 1, captured: 2, refunded: 3, failed: 4 }
+    enum refund_status: { null: 0, partial: 1, full: 2 }
+  end
+end

--- a/app/models/solidus_razorpay/razorpay_payment.rb
+++ b/app/models/solidus_razorpay/razorpay_payment.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SolidusRazorpay
+  class RazorpayPayment < SolidusSupport.payment_method_parent_class
+    preference :razorpay_key, :string
+    preference :razorpay_secret, :string
+    preference :razorpay_test_environment, :boolean
+
+    def gateway_class
+      ::SolidusRazorpay::Gateway
+    end
+
+    def payment_source_class
+      ::SolidusRazorpay::PaymentSource
+    end
+
+    def partial_name
+      "razorpay"
+    end
+  end
+end

--- a/db/migrate/20220209082405_create_solidus_razorpay_payment_sources.rb
+++ b/db/migrate/20220209082405_create_solidus_razorpay_payment_sources.rb
@@ -1,0 +1,23 @@
+class CreateSolidusRazorpayPaymentSources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :solidus_razorpay_payment_sources do |t|
+      t.integer :payment_method_id, index: true
+      t.string :razorpay_order_id, null: false
+      t.string :razorpay_payment_id
+      t.string :currency
+      t.string :method
+      t.string :status
+      t.integer :amount_refunded
+      t.integer :refund_status, default: 0
+      t.boolean :captured
+      t.integer :amount
+      t.boolean :international
+      t.string :error_code
+      t.string :error_description
+      t.string :error_source
+      t.string :error_step
+      t.string :error_reason
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/solidus_razorpay/install/install_generator.rb
+++ b/lib/generators/solidus_razorpay/install/install_generator.rb
@@ -6,10 +6,6 @@ module SolidusRazorpay
       class_option :auto_run_migrations, type: :boolean, default: false
       source_root File.expand_path('templates', __dir__)
 
-      def copy_initializer
-        template 'initializer.rb', 'config/initializers/solidus_razorpay.rb'
-      end
-
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_razorpay\n"
         append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_razorpay\n"

--- a/lib/solidus_razorpay/configuration.rb
+++ b/lib/solidus_razorpay/configuration.rb
@@ -3,8 +3,7 @@
 module SolidusRazorpay
   class Configuration
     # Define here the settings for this extension, e.g.:
-    #
-    # attr_accessor :my_setting
+    attr_accessor :razorpay_key, :razorpay_secret, :razorpay_test_environment
   end
 
   class << self

--- a/lib/solidus_razorpay/engine.rb
+++ b/lib/solidus_razorpay/engine.rb
@@ -11,6 +11,35 @@ module SolidusRazorpay
 
     engine_name 'solidus_razorpay'
 
+    initializer "solidus_razorpay.add_static_preference", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << SolidusRazorpay::RazorpayPayment
+      Spree::Config.static_model_preferences.add(
+        SolidusRazorpay::RazorpayPayment,
+        'razorpay_credentials', {
+          razorpay_key: ENV['RAZORPAY_KEY'],
+          razorpay_secret: ENV['RAZORPAY_SECRET'],
+          razorpay_test_environment: ENV['RAZORPAY_TEST_ENV'],
+        }
+      )
+      Spree::PermittedAttributes.source_attributes.concat [
+        :razorpay_order_id,
+        :razorpay_payment_id,
+        :currency,
+        :method,
+        :status,
+        :amount_refunded,
+        :refund_status,
+        :captured,
+        :amount,
+        :international,
+        :error_code,
+        :error_description,
+        :error_source,
+        :error_step,
+        :error_reason
+      ]
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec

--- a/spec/models/solidus_razorpay/gateway_spec.rb
+++ b/spec/models/solidus_razorpay/gateway_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe SolidusRazorpay::Gateway, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/solidus_razorpay/payment_source_spec.rb
+++ b/spec/models/solidus_razorpay/payment_source_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe SolidusRazorpay::PaymentSource, type: :model do
+  let(:column_list) {
+    [
+      'id',
+      'payment_method_id',
+      'razorpay_order_id',
+      'razorpay_payment_id',
+      'currency',
+      'method',
+      'status',
+      'amount_refunded',
+      'refund_status',
+      'captured',
+      'amount',
+      'international',
+      'error_code',
+      'error_description',
+      'error_source',
+      'error_step',
+      'error_reason',
+      'created_at',
+      'updated_at'
+    ]
+  }
+
+  describe 'Check Model Integrity' do
+    it 'has correct table name' do
+      expect(described_class.table_name).to eq 'solidus_razorpay_payment_sources'
+    end
+
+    it 'has correct attributes' do
+      expect(described_class.new.attributes.keys).to eq column_list
+    end
+  end
+end

--- a/spec/models/solidus_razorpay/razorpay_payment_spec.rb
+++ b/spec/models/solidus_razorpay/razorpay_payment_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe SolidusRazorpay::RazorpayPayment, type: :model do
+  describe '#gateway_class' do
+    it 'has correct gateway class' do
+      expect(described_class.new.gateway_class).to eq SolidusRazorpay::Gateway
+    end
+  end
+
+  describe '#payment_source_class' do
+    it 'has correct payment_source class' do
+      expect(described_class.new.payment_source_class).to eq SolidusRazorpay::PaymentSource
+    end
+  end
+
+  describe '#partial_name' do
+    it 'has correct partial name' do
+      expect(described_class.new.partial_name).to eq 'razorpay'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
+require 'pry'
+
 # Run Coverage report
 require 'solidus_dev_support/rspec/coverage'
 


### PR DESCRIPTION
This commit adds a Gateway, a PaymentMethod and a PaymentSource for Razorpay.

- The gateway is supposed to hold methods for interacting with the Razorpay's API.
- The PaymentMethod holds all the configuration data for Razorpay on Solidus.
- The PaymentSource is supposed to store information coming to Solidus from the Payment Service.