### PR TITLE
Integrate Razorpay Checkout Form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 require:
   - solidus_dev_support/rubocop
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 AllCops:
   NewCops: disable

--- a/app/assets/javascripts/solidus_razorpay.js
+++ b/app/assets/javascripts/solidus_razorpay.js
@@ -1,0 +1,145 @@
+let key;
+let amount;
+let razorpayOrderId;
+let orderId;
+let receipt;
+let color;
+let storeName;
+let name;
+let email;
+let contactNumber;
+let options;
+let rzpButton;
+let orderToken;
+let currency;
+let frontend;
+
+const paymentFailed = (response) => {
+  alert(response.error.code);
+  alert(response.error.description);
+  alert(response.error.source);
+  alert(response.error.step);
+  alert(response.error.reason);
+  alert(response.error.metadata.order_id);
+  alert(response.error.metadata.payment_id);
+};
+
+const setPaymentMethod = () => {
+  if (frontend) {
+    paymentMethodId = document.querySelector('[name="order[payments_attributes][][payment_method_id]"]:checked').value
+  } else {
+    paymentMethodId = document.querySelector('[name="payment[payment_method_id]"]:checked').value
+  }
+}
+
+const intializeCheckout = () => {
+  setPaymentMethod();
+  const body = JSON.stringify({
+    receipt: receipt,
+    amount: amount,
+    orderId: orderId,
+    paymentMethodId: paymentMethodId
+  });
+
+  return fetch('/api/initialize_checkout', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      "X-Spree-Order-Token": orderToken
+    },
+    body
+  })
+}
+
+const paymentSuccess = async (data) => {
+  let floatAmount = (Number.parseFloat(amount) * 0.01).toPrecision(4)
+
+  const body = JSON.stringify({
+    order_token: orderToken,
+    payment: {
+      amount: floatAmount,
+      payment_method_id: paymentMethodId,
+      source_attributes: {
+        razorpay_order_id: razorpayOrderId,
+        razorpay_payment_id: data.razorpay_payment_id
+      }
+    },
+  });
+
+  return resp = await fetch('/api/checkouts/' + receipt + '/payments', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      "X-Spree-Order-Token": orderToken
+    },
+    body,
+  });
+}
+
+const advanceOrder = async () => {
+  return fetch('/api/checkouts/' + receipt + '/advance', {
+    method: "PUT",
+    headers: {
+      'Content-Type': 'application/json',
+      "X-Spree-Order-Token": orderToken
+    },
+    data: {
+      order_token: orderToken
+    }
+  })
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  rzpButton = document.getElementById('rzp-button1');
+  if(rzpButton) {
+    amount = rzpButton.dataset.amount;
+    receipt = rzpButton.dataset.receipt;
+    currency = rzpButton.dataset.currency;
+    storeName = rzpButton.dataset.storeName;
+    name = rzpButton.dataset.name;
+    email = rzpButton.dataset.email;
+    contactNumber = rzpButton.dataset.contactNumber;
+    orderToken = rzpButton.dataset.orderToken;
+    orderId = rzpButton.dataset.orderId;
+    frontend = rzpButton.dataset.frontend
+
+    options = {
+      "key": '',
+      "amount": amount,
+      "currency": currency,
+      "name": storeName,
+      "order_id": '',
+      "handler": async function (response) {
+          // Call Payment API to create payment source for order and update status
+          await paymentSuccess(response);
+          await advanceOrder();
+          if (frontend) {
+            window.location.href = '/checkout/confirm';
+          }
+      },
+      "prefill": {
+          "name": name,
+          "email": email,
+      },
+      "theme": {
+          "color": 'red'
+      },
+    };
+
+    rzpButton.onclick = async function(e) {
+      e.preventDefault()
+      // CAll API to create Razorpay Order
+      intializeCheckout()
+      .then((resp) => resp.json())
+      .then((response) => {
+        options.order_id = razorpayOrderId = response.razorpayOrderId;
+        options.key = response.razorpayKey;
+      })
+      .then(() => {
+        let rzp1 = new Razorpay(options);
+        rzp1.on('payment.failed', (response) => paymentFailed(response));
+        rzp1.open()
+      });
+    }
+  }
+});

--- a/app/assets/javascripts/spree/backend/solidus_razorpay.js
+++ b/app/assets/javascripts/spree/backend/solidus_razorpay.js
@@ -1,2 +1,4 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'
+
+//= require solidus_razorpay

--- a/app/assets/javascripts/spree/frontend/solidus_razorpay.js
+++ b/app/assets/javascripts/spree/frontend/solidus_razorpay.js
@@ -1,2 +1,4 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/frontend/all.js'
+
+//= require solidus_razorpay

--- a/app/controllers/solidus_razorpay/api/checkout_controller.rb
+++ b/app/controllers/solidus_razorpay/api/checkout_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SolidusRazorpay
+  module Api
+    class CheckoutController < ApplicationController
+      include SolidusRazorpay::Api::CheckoutHelper
+      protect_from_forgery unless: -> { request.format.json? }
+
+      def index
+        payment_method = set_payment_method
+        razorpay_order = create_order(params, payment_method)
+        razorpay_key = payment_method.preferences[:razorpay_key]
+        respond_to do |format|
+          format.json {
+            render json: { success: true, razorpayOrderId: razorpay_order.id, razorpayKey: razorpay_key }
+          }
+        end
+      rescue StandardError => e
+        error_message = e.to_s
+        logger.error error_message
+        respond_to do |format|
+          format.json { render json: { success: false } }
+        end
+      end
+
+      private
+
+      def set_payment_method
+        payment_method_id = params[:paymentMethodId]
+        Spree::PaymentMethod.find(payment_method_id)
+      end
+    end
+  end
+end

--- a/app/helpers/solidus_razorpay/api/checkout_helper.rb
+++ b/app/helpers/solidus_razorpay/api/checkout_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusRazorpay
+  module Api
+    module CheckoutHelper
+      def create_order(params, payment_method)
+        receipt = params[:receipt]
+        amount = params[:amount]
+        order = Spree::Order.find(params[:orderId])
+
+        razorpay_key = payment_method.preferences[:razorpay_key]
+        razorpay_secret = payment_method.preferences[:razorpay_secret]
+
+        gateway = SolidusRazorpay::Gateway.new({ razorpay_key: razorpay_key, razorpay_secret: razorpay_secret })
+        gateway.create_order(amount, receipt, order.currency)
+      end
+    end
+  end
+end

--- a/app/models/solidus_razorpay/gateway.rb
+++ b/app/models/solidus_razorpay/gateway.rb
@@ -1,17 +1,60 @@
 # frozen_string_literal: true
 
+require 'razorpay'
+
 module SolidusRazorpay
   class Gateway
-    def initialize(razorpay_key, razorpay_secret)
-      Razorpay.setup(razorpay_key, razorpay_secret)
+    def initialize(options)
+      Razorpay.setup(options[:razorpay_key], options[:razorpay_secret])
     end
 
-    def authorize(_amount, payment_source, _gateway_options); end
+    def authorize(_amount, _payment_source, gateway_options)
+      payment = gateway_options[:originator]
+      razorpay_payment_id = payment.source.razorpay_payment_id
+      razorpay_payment = retrieve_payment(razorpay_payment_id)
+      update_razorpay_source(payment.source, razorpay_payment)
+      ActiveMerchant::Billing::Response.new(
+        true,
+        'Transaction approved',
+        razorpay_payment.attributes,
+        authorization: razorpay_payment.id
+      )
+    rescue StandardError => e
+      ActiveMerchant::Billing::Response.new(false, e.message, {})
+    end
 
     def capture(float_amount, order_number, gateway_options); end
 
     def void(order_number, gateway_options); end
 
     def purchase(float_amount, payment_source, gateway_options); end
+
+    def create_order(amount, receipt, currency)
+      Razorpay::Order.create(amount: amount, currency: currency, receipt: receipt)
+    end
+
+    def retrieve_payment(payment_id)
+      Razorpay::Payment.fetch(payment_id)
+    end
+
+    private
+
+    def update_razorpay_source(payment_source, razorpay_payment)
+      payment_source.currency = razorpay_payment.currency
+      payment_source.method = razorpay_payment.method
+      payment_source.status = razorpay_payment.status
+      payment_source.amount_refunded = razorpay_payment.amount_refunded
+      payment_source.refund_status = razorpay_payment.refund_status
+      payment_source.captured = razorpay_payment.captured
+      payment_source.amount = razorpay_payment.amount
+      payment_source.international = razorpay_payment.international
+      payment_source.error_code = razorpay_payment.error_code
+      payment_source.error_description = razorpay_payment.error_description
+      payment_source.error_source = razorpay_payment.error_source
+      payment_source.error_step = razorpay_payment.error_step
+      payment_source.error_reason = razorpay_payment.error_reason
+
+      payment_source.save!
+    end
   end
 end

--- a/app/views/spree/admin/payments/source_forms/_razorpay.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_razorpay.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/shared/razorpay', frontend: false %>

--- a/app/views/spree/checkout/payment/_razorpay.html.erb
+++ b/app/views/spree/checkout/payment/_razorpay.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/shared/razorpay', frontend: true %>

--- a/app/views/spree/shared/_razorpay.html.erb
+++ b/app/views/spree/shared/_razorpay.html.erb
@@ -1,0 +1,15 @@
+<button id="rzp-button1"
+  data-order-id="<%= @order.id %>"
+  data-store-name="<%= @order.store.name %>"
+  data-amount= "<%= @order.display_outstanding_balance.money.fractional %>"
+  data-receipt= "<%= @order.number %>"
+  data-order-token ="<%= @order.guest_token %>"
+  data-name="<%= @order.bill_address.name %>"
+  data-email="<%= @order.email %>"
+  data-contact-number="<%= @order.bill_address.phone %>"
+  data-currency="<%= @order.currency %>"
+  data-frontend="<%= frontend %>"
+>
+  <%= t('razorpay.pay_with_razorpay') %>
+</button>
+<script src="https://checkout.razorpay.com/v1/checkout.js"></script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,5 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: Hello world
+  razorpay:
+    pay_with_razorpay: 'Pay with Razorpay'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  post '/api/initialize_checkout', to: '/solidus_razorpay/api/checkout#index', as: 'razorpay_initialize_checkout'
 end

--- a/lib/solidus_razorpay/testing_support/factories.rb
+++ b/lib/solidus_razorpay/testing_support/factories.rb
@@ -1,4 +1,38 @@
 # frozen_string_literal: true
 
+require 'razorpay'
+
 FactoryBot.define do
+  factory :razorpay_payment_method, class: SolidusRazorpay::RazorpayPayment do
+    name { 'Razorpay' }
+    type { 'SolidusRazorpay::RazorpayPayment' }
+    active { true }
+    preferences {
+      { razorpay_key: 'Razorpay_Key', razorpay_secret: 'Razorpay_Secret', razorpay_test_environment: false }
+    }
+  end
+
+  factory :razorpay_payment_source, class: SolidusRazorpay::PaymentSource do
+    association :payment_method
+    razorpay_order_id { "order_#{random_string}" }
+    razorpay_payment_id { "payment_#{random_string}" }
+    currency { 'INR' }
+    status { 'authorized' }
+    amount_refunded { 0 }
+    refund_status { 'null' }
+    captured { false }
+    amount { 100 }
+    international { false }
+    error_code { nil }
+    error_description { nil }
+    error_source { nil }
+    error_step { nil }
+    error_reason { nil }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
+  end
+end
+
+def random_string
+  ('a'..'z').to_a.shuffle.join
 end

--- a/spec/helpers/solidus_razorpay/api/checkout_helper_spec.rb
+++ b/spec/helpers/solidus_razorpay/api/checkout_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe SolidusRazorpay::Api::CheckoutHelper, type: :helper do
+  let(:spree_user) { create(:user_with_addresses) }
+  let(:spree_address) { spree_user.addresses.first }
+  let(:order) { create(:order, bill_address: spree_address, ship_address: spree_address, user: spree_user) }
+  let(:amount) { order.display_outstanding_balance.money.fractional }
+  let(:payment_method) { create(:razorpay_payment_method) }
+  let(:razorpay_order) {
+    Razorpay::Order.new(
+      'id' => 'order_IgpDqlOTp1beGM',
+      'entity' => 'order',
+      'amount' => amount,
+      'amount_paid': 0,
+      'amount_due' => 100,
+      'currency' => 'INR',
+      'receipt' => order.number,
+      'status' => 'created',
+      'attempts' => 0,
+      'notes' => []
+    )
+  }
+
+  before do
+    allow(Razorpay::Order).to receive(:create) { razorpay_order }
+  end
+
+  describe '#create_order' do
+    subject(:response) { create_order(params, payment_method) }
+
+    let(:params) { { orderId: order.id, amount: amount, receipt: order.number } }
+
+    it 'successfully returns a Razorpay::Order object' do
+      expect(response.class).to eq Razorpay::Order
+    end
+
+    it 'returns the correct order id in the object' do
+      expect(response.id).to eq 'order_IgpDqlOTp1beGM'
+    end
+  end
+end

--- a/spec/models/solidus_razorpay/gateway_spec.rb
+++ b/spec/models/solidus_razorpay/gateway_spec.rb
@@ -1,5 +1,141 @@
 require 'spec_helper'
 
 RSpec.describe SolidusRazorpay::Gateway, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:spree_user) { create(:user_with_addresses) }
+  let(:spree_address) { spree_user.addresses.first }
+  let(:order) { create(:order, bill_address: spree_address, ship_address: spree_address, user: spree_user) }
+  let(:amount) { order.display_outstanding_balance.money.fractional }
+  let(:receipt) { order.number }
+  let(:payment_source) { create(:razorpay_payment_source) }
+  let(:payment_method) { create(:razorpay_payment_method) }
+  let(:payment) {
+    create(:payment, order: order, source_id: payment_source.id, source_type: SolidusRazorpay::PaymentSource,
+      payment_method: payment_method, response_code: nil)
+  }
+  let(:gateway) {
+    described_class.new({
+      razorpay_key: payment_method.preferences[:razorpay_key],
+      razorpay_secret: payment_method.preferences[:razorpay_secret]
+    })
+  }
+  let(:razorpay_order) {
+    Razorpay::Order.new(
+      'id' => 'order_IgpDqlOTp1beGM',
+      'entity' => 'order',
+      'amount' => amount,
+      'amount_paid': 0,
+      'amount_due' => 100,
+      'currency' => 'INR',
+      'receipt' => receipt,
+      'status' => 'created',
+      'attempts' => 0,
+      'notes' => []
+    )
+  }
+  let(:razorpay_payment_response) {
+    Razorpay::Payment.new(
+      'id' => 'pay_IfyJVYHeAaL6AY',
+      'entity' => 'payment',
+      'amount' => 100,
+      'currency' => 'USD',
+      'base_amount' => 7560,
+      'base_currency' => 'INR',
+      'status' => 'captured',
+      'order_id' => 'order_IgDqlOTp1beGM',
+      'method' => 'card',
+      'amount_refunded' => 0,
+      'refund_status' => nil,
+      'captured' => true,
+      'description' => 'Payment to Stark Industries',
+      'card_id' => 'card_IfyJVazEMj50uH',
+      'card' => {
+        'id' => 'card_Ifx2egIqLbumMB',
+        'entity' => 'card',
+        'name' => 'Peter Parker',
+        'last4' => '1111',
+        'network' => 'Visa',
+        'type' => 'debit',
+        'sub_type' => 'consumer'
+      },
+      'email' => 'abcd@gmail.com',
+      'contact' => '+121345678901',
+      'fee' => 3909,
+      'tax' => 0,
+      'acquirer_data' => { 'auth_code' => '171526' }
+    )
+  }
+  let(:razorpay_payment_authorized) {
+    Razorpay::Payment.new(
+      'id' => 'pay_IfyJVYHeAaL6AY',
+      'entity' => 'payment',
+      'amount' => 100,
+      'currency' => 'USD',
+      'base_amount' => 7560,
+      'base_currency' => 'INR',
+      'status' => 'authorized',
+      'order_id' => 'order_IgDqlOTp1beGM',
+      'method' => 'card',
+      'international' => false,
+      'amount_refunded' => 0,
+      'refund_status' => nil,
+      'captured' => false,
+      'description' => 'Payment to Stark Industries',
+      'card_id' => 'card_IfyJVazEMj50uH',
+      'email' => 'abcd@gmail.com',
+      'contact' => '+121345678901',
+      'fee' => 3909,
+      'tax' => 0,
+      'error_code' => nil,
+      'error_description' => nil,
+      'error_source' => nil,
+      'error_step' => nil,
+      'error_reason' => nil,
+      'acquirer_data' => { 'auth_code' => '171526' }
+    )
+  }
+
+  describe '#create_order' do
+    before do
+      allow(Razorpay::Order).to receive(:create) { razorpay_order }
+    end
+
+    it 'creates a razorpay order' do
+      expect(gateway.create_order(amount, receipt, 'INR')).to eq razorpay_order
+    end
+  end
+
+  describe '#retrieve_payment' do
+    subject(:retrieved_payment) { gateway.retrieve_payment('pay_IfyJVYHeAaL6AY') }
+
+    before do
+      allow(Razorpay::Payment).to receive(:fetch).and_return(razorpay_payment_response)
+    end
+
+    it 'retrieves a payment from Razorpay' do
+      expect(retrieved_payment).to eq razorpay_payment_response
+    end
+
+    it 'retrieves the correct id from Razorpay' do
+      expect(retrieved_payment.id).to eq 'pay_IfyJVYHeAaL6AY'
+    end
+  end
+
+  describe '#authorize' do
+    subject(:authorize) { gateway.authorize(100, nil, gateway_options) }
+
+    let(:gateway_options) { { originator: payment } }
+
+    before do
+      allow(Razorpay::Payment).to receive(:fetch).and_return(razorpay_payment_authorized)
+      authorize
+    end
+
+    it 'returns an ActiveMerchant::Billing::Response' do
+      expect(authorize).to be_an_instance_of(ActiveMerchant::Billing::Response)
+    end
+
+    it 'returns a successfull ActiveMerchant::Billing::Response' do
+      expect(authorize.success?).to be true
+    end
+  end
 end

--- a/spec/requests/solidus_razorpay/api/checkout_spec.rb
+++ b/spec/requests/solidus_razorpay/api/checkout_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe "SolidusRazorpay::Api::Checkout", type: :request do
+  let(:spree_user) { create(:user_with_addresses) }
+  let(:spree_address) { spree_user.addresses.first }
+  let(:order) { create(:order, bill_address: spree_address, ship_address: spree_address, user: spree_user) }
+  let(:amount) { order.display_outstanding_balance.money.fractional }
+  let(:payment_method) { create(:razorpay_payment_method) }
+  let(:razorpay_order) {
+    Razorpay::Order.new(
+      'id' => 'order_IgpDqlOTp1beGM',
+      'entity' => 'order',
+      'amount' => amount,
+      'amount_paid': 0,
+      'amount_due' => 100,
+      'currency' => 'INR',
+      'receipt' => order.number,
+      'status' => 'created',
+      'attempts' => 0,
+      'notes' => []
+    )
+  }
+
+  before do
+    allow(Razorpay::Order).to receive(:create) { razorpay_order }
+  end
+
+  describe 'POST /api/initialize_checkout' do
+    it 'returns a successful response' do
+      post '/api/initialize_checkout.json', params: {
+        paymentMethodId: payment_method.id,
+        orderId: order.id,
+        receipt: order.number,
+        amount: order.display_outstanding_balance.money.fractional
+      }
+      expect(response.status).to eq 200
+    end
+
+    it 'returns a the correct response body' do
+      post '/api/initialize_checkout.json', params: {
+        paymentMethodId: payment_method.id,
+        orderId: order.id,
+        receipt: order.number,
+        amount: order.display_outstanding_balance.money.fractional
+      }
+      expect(response.body).to eq({ success: true, razorpayOrderId: razorpay_order.id,
+                                    razorpayKey: payment_method.preferences[:razorpay_key] }.to_json)
+    end
+  end
+end


### PR DESCRIPTION
This commit enables the razorpay checkout form.
The razorpay checkout form is initialized from the payment page and allows an user to make a payment by using Razorpay.
The order and payment on razorpay's end are created.
This commit allows the user to make a successful checkout by using the Razorpay Payment Method.