### PR TITLE
[FIX] Incorrect Status implementation on payment_source

### DIFF
--- a/app/models/solidus_razorpay/payment_source.rb
+++ b/app/models/solidus_razorpay/payment_source.rb
@@ -4,7 +4,5 @@ require_dependency 'solidus_razorpay'
 
 module SolidusRazorpay
   class PaymentSource < SolidusSupport.payment_source_parent_class
-    enum status: { created: 0, authorized: 1, captured: 2, refunded: 3, failed: 4 }
-    enum refund_status: { null: 0, partial: 1, full: 2 }
   end
 end

--- a/db/migrate/20220209082405_create_solidus_razorpay_payment_sources.rb
+++ b/db/migrate/20220209082405_create_solidus_razorpay_payment_sources.rb
@@ -8,7 +8,7 @@ class CreateSolidusRazorpayPaymentSources < ActiveRecord::Migration[6.1]
       t.string :method
       t.string :status
       t.integer :amount_refunded
-      t.integer :refund_status, default: 0
+      t.string :refund_status
       t.boolean :captured
       t.integer :amount
       t.boolean :international

--- a/spec/models/solidus_razorpay/gateway_spec.rb
+++ b/spec/models/solidus_razorpay/gateway_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe SolidusRazorpay::Gateway, type: :model do
       'error_source' => nil,
       'error_step' => nil,
       'error_reason' => nil,
-      'acquirer_data' => { 'auth_code' => '171526' }
     )
   }
 
@@ -127,7 +126,6 @@ RSpec.describe SolidusRazorpay::Gateway, type: :model do
 
     before do
       allow(Razorpay::Payment).to receive(:fetch).and_return(razorpay_payment_authorized)
-      authorize
     end
 
     it 'returns an ActiveMerchant::Billing::Response' do
@@ -136,6 +134,16 @@ RSpec.describe SolidusRazorpay::Gateway, type: :model do
 
     it 'returns a successfull ActiveMerchant::Billing::Response' do
       expect(authorize.success?).to be true
+    end
+
+    it 'updates the payment source status' do
+      authorize
+      expect(payment.source.status).to eq razorpay_payment_authorized.status
+    end
+
+    it 'updates the payment source method' do
+      authorize
+      expect(payment.source.method).to eq razorpay_payment_authorized.method
     end
   end
 end


### PR DESCRIPTION
This commit fixes an issue with the payment source where status was not being recorded.
The issue was fixed by removing enums defined on the model and changing the type of the column in the migration from integer to string.
Columns affected in the table solidus_razorpay_payment_sources are:
- status
- refund_status