### PR TITLE
Enable Payments from Backend

### DIFF
--- a/app/assets/javascripts/solidus_razorpay.js
+++ b/app/assets/javascripts/solidus_razorpay.js
@@ -13,6 +13,7 @@ let rzpButton;
 let orderToken;
 let currency;
 let frontend;
+let successCallbackPath;
 
 const paymentFailed = (response) => {
   alert(response.error.code);
@@ -25,7 +26,7 @@ const paymentFailed = (response) => {
 };
 
 const setPaymentMethod = () => {
-  if (frontend) {
+  if (frontend === 'true') {
     paymentMethodId = document.querySelector('[name="order[payments_attributes][][payment_method_id]"]:checked').value
   } else {
     paymentMethodId = document.querySelector('[name="payment[payment_method_id]"]:checked').value
@@ -101,7 +102,8 @@ document.addEventListener('DOMContentLoaded', () => {
     contactNumber = rzpButton.dataset.contactNumber;
     orderToken = rzpButton.dataset.orderToken;
     orderId = rzpButton.dataset.orderId;
-    frontend = rzpButton.dataset.frontend
+    frontend = rzpButton.dataset.frontend;
+    successCallbackPath = rzpButton.dataset.successCallbackPath;
 
     options = {
       "key": '',
@@ -114,7 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
           await paymentSuccess(response);
           await advanceOrder();
           if (frontend) {
-            window.location.href = '/checkout/confirm';
+            window.location.href = successCallbackPath;
           }
       },
       "prefill": {

--- a/app/views/spree/admin/payments/source_forms/_razorpay.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_razorpay.html.erb
@@ -1,1 +1,1 @@
-<%= render 'spree/shared/razorpay', frontend: false %>
+<%= render 'spree/shared/razorpay', frontend: false, success_callback_path: "/admin/orders/#{@order.number}/confirm" %>

--- a/app/views/spree/checkout/payment/_razorpay.html.erb
+++ b/app/views/spree/checkout/payment/_razorpay.html.erb
@@ -1,1 +1,1 @@
-<%= render 'spree/shared/razorpay', frontend: true %>
+<%= render 'spree/shared/razorpay', frontend: true, success_callback_path: '/checkout/confirm' %>

--- a/app/views/spree/shared/_razorpay.html.erb
+++ b/app/views/spree/shared/_razorpay.html.erb
@@ -9,6 +9,7 @@
   data-contact-number="<%= @order.bill_address.phone %>"
   data-currency="<%= @order.currency %>"
   data-frontend="<%= frontend %>"
+  data-success-callback-path="<%= success_callback_path %>"
 >
   <%= t('razorpay.pay_with_razorpay') %>
 </button>


### PR DESCRIPTION
This commit aims to enable payments from the backend(admin side) of solidus.
Changes have been made to the views that render the checkout form partial to include different success callback paths for the frontend and backend.
The js files have been modified accordingly to accomodate these changes.