### PR TITLE
Remove extra fields from preferences in Payment Method

### DIFF
--- a/app/models/solidus_razorpay/razorpay_payment.rb
+++ b/app/models/solidus_razorpay/razorpay_payment.rb
@@ -4,7 +4,6 @@ module SolidusRazorpay
   class RazorpayPayment < SolidusSupport.payment_method_parent_class
     preference :razorpay_key, :string
     preference :razorpay_secret, :string
-    preference :razorpay_test_environment, :boolean
 
     def gateway_class
       ::SolidusRazorpay::Gateway

--- a/lib/solidus_razorpay/configuration.rb
+++ b/lib/solidus_razorpay/configuration.rb
@@ -2,8 +2,7 @@
 
 module SolidusRazorpay
   class Configuration
-    # Define here the settings for this extension, e.g.:
-    attr_accessor :razorpay_key, :razorpay_secret, :razorpay_test_environment
+    attr_accessor :razorpay_key, :razorpay_secret
   end
 
   class << self

--- a/lib/solidus_razorpay/engine.rb
+++ b/lib/solidus_razorpay/engine.rb
@@ -17,8 +17,7 @@ module SolidusRazorpay
         SolidusRazorpay::RazorpayPayment,
         'razorpay_credentials', {
           razorpay_key: ENV['RAZORPAY_KEY'],
-          razorpay_secret: ENV['RAZORPAY_SECRET'],
-          razorpay_test_environment: ENV['RAZORPAY_TEST_ENV'],
+          razorpay_secret: ENV['RAZORPAY_SECRET']
         }
       )
       Spree::PermittedAttributes.source_attributes.concat [


### PR DESCRIPTION
This commit removes extra fields from the Payment Method configuration which were accessed through it's preferences.
Specifically the razorpay_test_environment key has been removed because Razorpay generates different set of keys for it's Test and Production modes, so changing the keys should set the mode also.