### PR TITLE
Attach razorpay order to spree order

### DIFF
--- a/app/helpers/solidus_razorpay/api/checkout_helper.rb
+++ b/app/helpers/solidus_razorpay/api/checkout_helper.rb
@@ -4,15 +4,24 @@ module SolidusRazorpay
   module Api
     module CheckoutHelper
       def create_order(params, payment_method)
-        receipt = params[:receipt]
-        amount = params[:amount]
-        order = Spree::Order.find(params[:orderId])
-
         razorpay_key = payment_method.preferences[:razorpay_key]
         razorpay_secret = payment_method.preferences[:razorpay_secret]
-
         gateway = SolidusRazorpay::Gateway.new({ razorpay_key: razorpay_key, razorpay_secret: razorpay_secret })
-        gateway.create_order(amount, receipt, order.currency)
+
+        receipt = params[:receipt]
+        amount = params[:amount]
+
+        order = Spree::Order.find(params[:orderId])
+        razorpay_order_id = order.razorpay_order_id
+
+        razorpay_order = if razorpay_order_id.present?
+                           gateway.retrieve_order(razorpay_order_id)
+                         else
+                           gateway.create_order(amount, receipt, order.currency)
+                         end
+
+        order.update(razorpay_order_id: razorpay_order.id)
+        razorpay_order
       end
     end
   end

--- a/app/models/solidus_razorpay/gateway.rb
+++ b/app/models/solidus_razorpay/gateway.rb
@@ -64,6 +64,10 @@ module SolidusRazorpay
       Razorpay::Order.create(amount: amount, currency: currency, receipt: receipt)
     end
 
+    def retrieve_order(order_id)
+      Razorpay::Order.fetch(order_id)
+    end
+
     def retrieve_payment(payment_id)
       Razorpay::Payment.fetch(payment_id)
     end

--- a/db/migrate/20220304063131_add_razorpay_order_id_to_spree_orders.rb
+++ b/db/migrate/20220304063131_add_razorpay_order_id_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddRazorpayOrderIdToSpreeOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :spree_orders, :razorpay_order_id, :string
+  end
+end

--- a/spec/helpers/solidus_razorpay/api/checkout_helper_spec.rb
+++ b/spec/helpers/solidus_razorpay/api/checkout_helper_spec.rb
@@ -3,7 +3,23 @@ require 'spec_helper'
 RSpec.describe SolidusRazorpay::Api::CheckoutHelper, type: :helper do
   let(:spree_user) { create(:user_with_addresses) }
   let(:spree_address) { spree_user.addresses.first }
-  let(:order) { create(:order, bill_address: spree_address, ship_address: spree_address, user: spree_user) }
+  let(:order) {
+    create(
+      :order,
+      bill_address: spree_address,
+      ship_address: spree_address,
+      user: spree_user
+    )
+  }
+  let(:order_with_razorpay) {
+    create(
+      :order,
+      bill_address: spree_address,
+      ship_address: spree_address,
+      user: spree_user,
+      razorpay_order_id: 'order_IgpDqlOTp1beGM'
+    )
+  }
   let(:amount) { order.display_outstanding_balance.money.fractional }
   let(:payment_method) { create(:razorpay_payment_method) }
   let(:razorpay_order) {
@@ -26,16 +42,36 @@ RSpec.describe SolidusRazorpay::Api::CheckoutHelper, type: :helper do
   end
 
   describe '#create_order' do
-    subject(:response) { create_order(params, payment_method) }
+    context 'when order does not have a razorpay_order_id' do
+      subject(:response) { create_order(params, payment_method) }
 
-    let(:params) { { orderId: order.id, amount: amount, receipt: order.number } }
+      let(:params) { { orderId: order.id, amount: amount, receipt: order.number } }
 
-    it 'successfully returns a Razorpay::Order object' do
-      expect(response.class).to eq Razorpay::Order
+      it 'successfully returns a Razorpay::Order object' do
+        expect(response.class).to eq Razorpay::Order
+      end
+
+      it 'returns the correct order id in the object' do
+        expect(response.id).to eq 'order_IgpDqlOTp1beGM'
+      end
     end
 
-    it 'returns the correct order id in the object' do
-      expect(response.id).to eq 'order_IgpDqlOTp1beGM'
+    context 'when order has a razorpay_order_id' do
+      subject(:response) { create_order(params, payment_method) }
+
+      let(:params) { { orderId: order_with_razorpay.id, amount: amount, receipt: order_with_razorpay.number } }
+
+      before do
+        allow(Razorpay::Order).to receive(:fetch) { razorpay_order }
+      end
+
+      it 'successfully returns a Razorpay::Order object' do
+        expect(response.class).to eq Razorpay::Order
+      end
+
+      it 'returns the correct order id in the object' do
+        expect(response.id).to eq 'order_IgpDqlOTp1beGM'
+      end
     end
   end
 end

--- a/spec/models/solidus_razorpay/gateway_spec.rb
+++ b/spec/models/solidus_razorpay/gateway_spec.rb
@@ -194,6 +194,16 @@ RSpec.describe SolidusRazorpay::Gateway, type: :model do
     end
   end
 
+  describe '#retrieve_order' do
+    before do
+      allow(Razorpay::Order).to receive(:fetch) { razorpay_order }
+    end
+
+    it 'creates a razorpay order' do
+      expect(gateway.retrieve_order(razorpay_order.id)).to eq razorpay_order
+    end
+  end
+
   describe '#retrieve_payment' do
     subject(:retrieved_payment) { gateway.retrieve_payment('pay_IfyJVYHeAaL6AY') }
 


### PR DESCRIPTION
This PR makes a fundamental change to how the extension works.

The major change is how the `razorpay_order` and the `spree_order` are linked and the way in which payments are made.

Earlier, for every payment request a new `razorpay_order` was created. This caused a lot of duplicate orders on the razorpay dashboard and was the wrong approach logically.

This PR changes that approach and links the `razorpay_order` and the `spree_order`. This allows the following
- Multiple payments to be made for the same `razorpay_order`.
- Each `razorpay_order` is linked to a single `spree_order` removing all duplicate orders from the razorpay dashboard
- Logically correct behaviour for the `razorpay_order`